### PR TITLE
Accept Slice(Uint8) in addition to String

### DIFF
--- a/examples/basic_get.cr
+++ b/examples/basic_get.cr
@@ -45,7 +45,8 @@ AMQP::Connection.start do |conn|
       msg = queue.get
       next unless msg
       counter += 1
-      puts "Received msg: #{msg.body}. Count: #{msg.message_count}"
+      body = String.new(msg.body)
+      puts "Received msg: #{body}. Count: #{msg.message_count}"
       msg.ack
       break if counter == COUNT
       sleep 0.5

--- a/examples/sender_receiver.cr
+++ b/examples/sender_receiver.cr
@@ -19,11 +19,13 @@ AMQP::Connection.start do |conn|
   queue = channel.queue(QUEUE_NAME)
   queue.bind(exchange, queue.name)
   queue.subscribe do |msg|
-    puts "Received msg (1): #{msg.body}"
+    body = String.new(msg.body)
+    puts "Received msg (1): #{body}"
     msg.ack
   end
   queue.subscribe do |msg|
-    puts "Received msg (2): #{msg.body}"
+    body = String.new(msg.body)
+    puts "Received msg (2): #{body}"
     msg.ack
   end
 

--- a/src/amqp/broker.cr
+++ b/src/amqp/broker.cr
@@ -41,8 +41,11 @@ class AMQP::Broker
 
       limit = @config.frame_max - Protocol::FRAME_HEADER_SIZE
       while payload && !payload.empty?
-        body, payload = payload[0, limit], (limit > payload.size ? "" : payload[limit, payload.size - limit])
-        frames << Protocol::BodyFrame.new(channel, body.to_slice)
+        if payload.size < limit
+          limit = payload.size
+        end
+        body, payload = payload[0, limit], (limit > payload.size ? Slice(UInt8).new(0) : payload[limit, payload.size - limit])
+        frames << Protocol::BodyFrame.new(channel, body)
       end
       send_frames(frames)
     else

--- a/src/amqp/channel.cr
+++ b/src/amqp/channel.cr
@@ -252,7 +252,6 @@ class AMQP::Channel
   #
   def publish(msg, exchange_name, key, mandatory = false, immediate = false)
     msg.properties.delivery_mode = Message::TRANSIENT if msg.properties.delivery_mode == 0
-    msg.properties.content_type = "application/octet-stream" if msg.properties.content_type.empty?
     publish = Protocol::Basic::Publish.new(0_u16, exchange_name, key, mandatory, immediate, msg.properties, msg.body)
     oneway_call(publish)
 

--- a/src/amqp/message.cr
+++ b/src/amqp/message.cr
@@ -16,8 +16,14 @@ class AMQP::Message
   # provided by amqp 'get' method
   property message_count : UInt32?
 
-  def initialize(@body : String, @properties = Protocol::Properties.new)
+  def initialize(body : String, @properties = Protocol::Properties.new)
+    @body = body.to_slice
   end
+
+  def initialize(@body : Slice(UInt8), @properties = Protocol::Properties.new)
+  end
+
+
 
   def ack
     if exchange = @exchange

--- a/src/amqp/spec091.cr
+++ b/src/amqp/spec091.cr
@@ -2124,7 +2124,11 @@ module AMQP::Protocol
 
       getter reserved_1, exchange, routing_key, mandatory, immediate, properties, payload
 
-      def initialize(@reserved_1 : UInt16, @exchange : String, @routing_key : String, @mandatory : Bool, @immediate : Bool, @properties : AMQP::Protocol::Properties, @payload : String)
+      def initialize(@reserved_1 : UInt16, @exchange : String, @routing_key : String, @mandatory : Bool, @immediate : Bool, @properties : AMQP::Protocol::Properties, @payload : Slice(UInt8))
+      end
+
+      def initialize(@reserved_1 : UInt16, @exchange : String, @routing_key : String, @mandatory : Bool, @immediate : Bool, @properties : AMQP::Protocol::Properties, payload : String)
+        @payload = payload.to_slice
       end
 
       def id


### PR DESCRIPTION
Allow messages to be bytes so that binary data can be sent (such as compressed data). Strings are cast with to_slice. Using strings for byte data runs into encoding errors.