### PR TITLE
Added properties parameter to HeaderFrame#initialize

### DIFF
--- a/src/amqp/broker.cr
+++ b/src/amqp/broker.cr
@@ -37,7 +37,7 @@ class AMQP::Broker
         raise Protocol::FrameError.new("unable to obtain the method's content")
       end
       properties, payload = method.content
-      frames << Protocol::HeaderFrame.new(channel, method.id.first, 0_u16, payload.size.to_u64)
+       frames << Protocol::HeaderFrame.new(channel, method.id.first, 0_u16, payload.size.to_u64, properties)
 
       limit = @config.frame_max - Protocol::FRAME_HEADER_SIZE
       while payload && !payload.empty?

--- a/src/amqp/protocol.cr
+++ b/src/amqp/protocol.cr
@@ -293,9 +293,8 @@ module AMQP::Protocol
     getter body_size
     getter properties
 
-    def initialize(@channel : UInt16, @cls_id : UInt16, @weight : UInt16, @body_size : UInt64)
+    def initialize(@channel : UInt16, @cls_id : UInt16, @weight : UInt16, @body_size : UInt64, @properties = Properties.new)
       @type = HEADERS
-      @properties = Properties.new
     end
 
     def self.parse(channel, size, io)


### PR DESCRIPTION
Properties are now sent along with the message, as illustrated by this modified sender_receiver.cr.

```crystal
require "../src/amqp"
require "secure_random"

COUNT         = 20
EXCHANGE_NAME = "sender_receiver"
QUEUE_NAME    = "sender_receiver"
STDOUT.sync = true

AMQP::Connection.start do |conn|
  conn.on_close do |code, msg|
    puts "CONNECTION CLOSED: #{code} - #{msg}"
  end

  channel = conn.channel
  channel.on_close do |code, msg|
    puts "CHANNEL CLOSED: #{code} - #{msg}"
  end

  exchange = channel.direct(EXCHANGE_NAME)
  queue = channel.queue(QUEUE_NAME)
  queue.bind(exchange, queue.name)
  queue.subscribe do |msg|
    puts msg.properties.content_type
    puts msg.properties.correlation_id
    puts msg.properties.reply_to
    puts "Received msg (1): #{msg.to_s}"
    puts
    msg.ack
  end
  queue.subscribe do |msg|
    puts "Received msg (2): #{msg.to_s}"
    msg.ack
  end

  COUNT.times do |idx|
    props = AMQP::Protocol::Properties.new(
      reply_to: "reply-to-me",
      correlation_id: SecureRandom.uuid,
      content_type: "application/text"
    )
    msg = AMQP::Message.new("test message: #{idx + 1}", props)
    exchange.publish(msg, QUEUE_NAME)
    sleep 0.1
  end

  queue.delete
  exchange.delete
  channel.close
end
```