### PR TITLE
Update Time and Time::Span methods for 0.24

### DIFF
--- a/src/amqp/broker.cr
+++ b/src/amqp/broker.cr
@@ -111,7 +111,7 @@ class AMQP::Broker
 
   def start_heartbeater
     return if @heartbeater_started
-    return if @config.heartbeat.ticks == 0
+    return if @config.heartbeat.total_nanoseconds == 0
     @heartbeater_started = true
     spawn { run_heartbeater }
   end

--- a/src/amqp/protocol.cr
+++ b/src/amqp/protocol.cr
@@ -83,7 +83,7 @@ module AMQP::Protocol
                    @reply_to = "",
                    @expiration = "",
                    @message_id = "",
-                   @timestamp = Time.new(0),
+                   @timestamp = Time.epoch(0),
                    @type = "",
                    @user_id = "",
                    @app_id = "",
@@ -174,7 +174,7 @@ module AMQP::Protocol
       flags = flags | FLAG_REPLY_TO         unless @reply_to.empty?
       flags = flags | FLAG_EXPIRATION       unless @expiration.empty?
       flags = flags | FLAG_MESSAGE_ID       unless @message_id.empty?
-      flags = flags | FLAG_TIMESTAMP        unless @timestamp.ticks == 0
+      flags = flags | FLAG_TIMESTAMP        unless @timestamp.epoch == 0
       flags = flags | FLAG_TYPE             unless @type.empty?
       flags = flags | FLAG_USER_ID          unless @user_id.empty?
       flags = flags | FLAG_APP_ID           unless @app_id.empty?
@@ -191,7 +191,7 @@ module AMQP::Protocol
       io.write_shortstr(@reply_to)         unless @reply_to.empty?
       io.write_shortstr(@expiration)       unless @expiration.empty?
       io.write_shortstr(@message_id)       unless @message_id.empty?
-      io.write_timestamp(@timestamp)       unless @timestamp.ticks == 0
+      io.write_timestamp(@timestamp)       unless @timestamp.epoch == 0
       io.write_shortstr(@type)             unless @type.empty?
       io.write_shortstr(@user_id)          unless @user_id.empty?
       io.write_shortstr(@app_id)           unless @app_id.empty?

--- a/src/amqp/timed_channel.cr
+++ b/src/amqp/timed_channel.cr
@@ -3,7 +3,7 @@
 module Timed
   class TimerChannel < Channel(Time)
     def initialize(@interval : Time::Span)
-      raise ArgumentError.new("invalid timespan") if @interval.ticks == 0
+      raise ArgumentError.new("invalid timespan") if @interval.total_nanoseconds == 0
       @start_time = Time.now
       super()
     end
@@ -41,7 +41,7 @@ module Timed
     end
 
     def receive(interval : Time::Span)
-      raise ArgumentError.new("invalid timespan") if interval.ticks == 0
+      raise ArgumentError.new("invalid timespan") if interval.total_nanoseconds == 0
       start_time = Time.now
 
       while empty?


### PR DESCRIPTION
Works with newer version of Crystal (0.24), see [epoch](https://crystal-lang.org/api/0.24.1/Time.html#epoch%28seconds%3AInt%29%3ATime-class-method)