### PR TITLE
Store channel instead of exchange in received message

### DIFF
--- a/src/amqp/channel.cr
+++ b/src/amqp/channel.cr
@@ -582,7 +582,7 @@ class AMQP::Channel
     when Protocol::Basic::Deliver
       msg.delivery_tag = content_method.delivery_tag
       msg.redelivered = content_method.redelivered
-      msg.exchange = @exchanges[content_method.exchange]
+      msg.channel = self
       msg.key = content_method.routing_key
       subscriber = @subscribers[content_method.consumer_tag]?
       unless subscriber
@@ -595,7 +595,7 @@ class AMQP::Channel
     when Protocol::Basic::GetOk
       msg.delivery_tag = content_method.delivery_tag
       msg.redelivered = content_method.redelivered
-      msg.exchange = @exchanges[content_method.exchange]
+      msg.channel = self
       msg.key = content_method.routing_key
       msg.message_count = content_method.message_count
       @msg.send(msg)

--- a/src/amqp/message.cr
+++ b/src/amqp/message.cr
@@ -1,4 +1,5 @@
-require "./exchange"
+# require "./exchange"
+require "./channel"
 
 class AMQP::Message
 
@@ -12,7 +13,7 @@ class AMQP::Message
   property delivery_tag : UInt64?
   property redelivered : Bool?
   # these two properties are also provider by 'return' method
-  property exchange : AMQP::Exchange?
+  property channel : AMQP::Channel?
   property key : String?
 
   # provided by amqp 'get' method
@@ -26,25 +27,25 @@ class AMQP::Message
   end
 
   def ack
-    if exchange = @exchange
+    if channel = @channel
       if tag = @delivery_tag
-        exchange.channel.ack(tag)
+        channel.ack(tag)
       end
     end
   end
 
   def reject(requeue = false)
-    if exchange = @exchange
+    if channel = @channel
       if tag = @delivery_tag
-        exchange.channel.reject(tag, requeue)
+        channel.reject(tag, requeue)
       end
     end
   end
 
   def nack(requeue = false)
-    if exchange = @exchange
+    if channel = @channel
       if tag = @delivery_tag
-        exchange.channel.nack(tag, requeue: requeue)
+        channel.nack(tag, requeue: requeue)
       end
     end
   end


### PR DESCRIPTION
This fixes the issue of having to declare the exchange that a message was sent from before receiving the message.

This should fix #19