### PR TITLE
Add TLS support

### DIFF
--- a/src/amqp/protocol.cr
+++ b/src/amqp/protocol.cr
@@ -83,7 +83,7 @@ module AMQP::Protocol
                    @reply_to = "",
                    @expiration = "",
                    @message_id = "",
-                   @timestamp = Time.epoch(0),
+                   @timestamp = Time::UNIX_EPOCH.as(Time),
                    @type = "",
                    @user_id = "",
                    @app_id = "",
@@ -174,7 +174,7 @@ module AMQP::Protocol
       flags = flags | FLAG_REPLY_TO         unless @reply_to.empty?
       flags = flags | FLAG_EXPIRATION       unless @expiration.empty?
       flags = flags | FLAG_MESSAGE_ID       unless @message_id.empty?
-      flags = flags | FLAG_TIMESTAMP        unless @timestamp.epoch == 0
+      flags = flags | FLAG_TIMESTAMP        unless @timestamp.to_unix == 0
       flags = flags | FLAG_TYPE             unless @type.empty?
       flags = flags | FLAG_USER_ID          unless @user_id.empty?
       flags = flags | FLAG_APP_ID           unless @app_id.empty?
@@ -191,7 +191,7 @@ module AMQP::Protocol
       io.write_shortstr(@reply_to)         unless @reply_to.empty?
       io.write_shortstr(@expiration)       unless @expiration.empty?
       io.write_shortstr(@message_id)       unless @message_id.empty?
-      io.write_timestamp(@timestamp)       unless @timestamp.epoch == 0
+      io.write_timestamp(@timestamp)       unless @timestamp.to_unix == 0
       io.write_shortstr(@type)             unless @type.empty?
       io.write_shortstr(@user_id)          unless @user_id.empty?
       io.write_shortstr(@app_id)           unless @app_id.empty?
@@ -607,7 +607,7 @@ module AMQP::Protocol
      end
 
      def write_timestamp(v : Time)
-       write(v.epoch.to_i64)
+       write(v.to_unix.to_i64)
      end
 
      protected def write_field(field)
@@ -682,9 +682,7 @@ module AMQP::Protocol
     def read_timestamp
       tv_sec = read_int64
       return nil unless tv_sec
-      spec = LibC::Timespec.new
-      spec.tv_sec = tv_sec
-      Time.new(spec)
+      Time.unix tv_sec
     end
 
     def flush

--- a/src/amqp/protocol.cr
+++ b/src/amqp/protocol.cr
@@ -392,7 +392,7 @@ module AMQP::Protocol
       @eof = false
     end
 
-    def initialize(@io : Socket)
+    def initialize(@io : ::IO::Buffered)
       @eof = false
     end
 

--- a/src/amqp/timed_channel.cr
+++ b/src/amqp/timed_channel.cr
@@ -15,7 +15,7 @@ module Timed
     private def sleep
       interval = Time.now - @start_time
       interval = @interval - interval
-      Fiber.sleep interval.total_seconds
+      sleep interval.total_seconds
     end
 
     private def receive_impl
@@ -52,7 +52,7 @@ module Timed
       end
 
       @queue.shift.tap do
-        Scheduler.enqueue @senders
+        Crystal::Scheduler.enqueue @senders
         @senders.clear
       end
     end
@@ -64,7 +64,7 @@ module Timed
     private def sleep(start_time, interval)
       cur_interval = Time.now - start_time
       interval = interval - cur_interval
-      Fiber.sleep interval.total_seconds
+      sleep interval.total_seconds
     end
   end
 end


### PR DESCRIPTION
Adding TLS/SSL support to network clients in Crystal is usually as simple as wrapping a `Socket` in an `OpenSSL::SSL::Context::Client`. In this case, I also had to change the types of the sockets to `IO::Buffered` (a superclass shared by `Socket` and `OpenSSL::SSL::Context::Client`) instead of making it a union type between the two classes.

This PR also adds support for taking a URL (in either `String` or `URI` form). I just found it easier to test this when I didn't have to slice up my CloudAMQP or Amazon MQ URLs manually. :-)

Also, this PR contains @carlhoerberg's commit from #30 (I needed it because I'm on 0.27). When that PR is merged, I'll merge `master` into this branch so it won't be in the diff.